### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#HardenFlash - Patching Flash binary to stop Flash exploits and zero-days
+# HardenFlash - Patching Flash binary to stop Flash exploits and zero-days
 
 Introduction
 ============


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
